### PR TITLE
Remove auto-applied extensions, add setup documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [6.0.0] - Unreleased
 
+### Breaking
+- Extensions are no longer auto-applied to framework classes (SiteConfig, SiteTree). Projects must opt in by adding the desired extensions to their own YAML config. See README.md for setup instructions.
+
 ### Changed
 - Upgraded to Silverstripe 6 compatibility
 - Updated PHP requirement to ^8.5

--- a/README.md
+++ b/README.md
@@ -36,13 +36,34 @@ SEO enhancements for Silverstripe.
 composer require catch/ss-seo
 ```
 
+## Setup
+
+Extensions are **not auto-applied**. Add the ones you need to your project's YAML config (e.g. `app/_config/extensions.yml`):
+
+```yaml
+SilverStripe\SiteConfig\SiteConfig:
+  extensions:
+    ss-robots-config: CatchDesign\SS\SEO\Extensions\SSRobotsConfigExtension
+
+SilverStripe\CMS\Model\SiteTree:
+  extensions:
+    ss-canonical: CatchDesign\SS\SEO\Extensions\CanonicalExtension
+    ss-site-tree-robots: CatchDesign\SS\SEO\Extensions\SiteTreeRobotsExtension
+```
+
+You can apply all three or pick only the ones you need. See descriptions below.
+
 ## Usage
 
 ### Robots.txt
 
+Requires: `SSRobotsConfigExtension` on `SiteConfig`.
+
 The module registers a route at `/robots.txt` that serves content from the `Robots` tab in **Settings > Site Configuration**. Edit the robots.txt content directly in the CMS.
 
 ### Canonical URLs
+
+Requires: `CanonicalExtension` on `SiteTree`.
 
 The `CanonicalExtension` automatically redirects (301) requests to the canonical URL for each page. It:
 - Strips `index.php` from URLs
@@ -50,6 +71,8 @@ The `CanonicalExtension` automatically redirects (301) requests to the canonical
 - Skips POST requests to avoid data loss
 
 ### Per-page Robots Meta Tag
+
+Requires: `SiteTreeRobotsExtension` on `SiteTree`.
 
 The `SiteTreeRobotsExtension` adds an `X-Robots-Tag` HTTP header to every page response. Configure per-page directives (noindex, nofollow, etc.) under **Page > Settings > Robots**.
 

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -1,15 +1,10 @@
 ---
 Name: ss-seo
 ---
+# Extensions are no longer auto-applied. See README.md for setup instructions.
+
 SilverStripe\SiteConfig\SiteConfig:
   enable_seo_cache_lifetime: true
-  extensions:
-    ss-robots-config: CatchDesign\SS\SEO\Extensions\SSRobotsConfigExtension
-
-SilverStripe\CMS\Model\SiteTree:
-  extensions:
-    ss-canonical: CatchDesign\SS\SEO\Extensions\CanonicalExtension
-    ss-site-tree-robots: CatchDesign\SS\SEO\Extensions\SiteTreeRobotsExtension
 
 SilverStripe\Core\Injector\Injector:
   SilverStripe\Assets\Image_Backend:

--- a/tests/Controllers/SSRobotsControllerTest.php
+++ b/tests/Controllers/SSRobotsControllerTest.php
@@ -2,12 +2,17 @@
 
 namespace CatchDesign\SS\SEO\Tests\Controllers;
 
+use CatchDesign\SS\SEO\Extensions\SSRobotsConfigExtension;
 use SilverStripe\Dev\FunctionalTest;
 use SilverStripe\SiteConfig\SiteConfig;
 
 class SSRobotsControllerTest extends FunctionalTest
 {
     protected $usesDatabase = true;
+
+    protected static $required_extensions = [
+        SiteConfig::class => [SSRobotsConfigExtension::class],
+    ];
 
     public function testRobotsTxtReturns200(): void
     {

--- a/tests/Extensions/CanonicalExtensionTest.php
+++ b/tests/Extensions/CanonicalExtensionTest.php
@@ -8,11 +8,16 @@ use SilverStripe\CMS\Controllers\ContentController;
 use SilverStripe\Control\Controller;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\Session;
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\SapphireTest;
 
 class CanonicalExtensionTest extends SapphireTest
 {
     protected $usesDatabase = true;
+
+    protected static $required_extensions = [
+        SiteTree::class => [CanonicalExtension::class],
+    ];
 
     protected function setUp(): void
     {

--- a/tests/Extensions/SSRobotsConfigExtensionTest.php
+++ b/tests/Extensions/SSRobotsConfigExtensionTest.php
@@ -2,6 +2,7 @@
 
 namespace CatchDesign\SS\SEO\Tests\Extensions;
 
+use CatchDesign\SS\SEO\Extensions\SSRobotsConfigExtension;
 use SilverStripe\Dev\SapphireTest;
 use SilverStripe\Forms\TextareaField;
 use SilverStripe\SiteConfig\SiteConfig;
@@ -9,6 +10,10 @@ use SilverStripe\SiteConfig\SiteConfig;
 class SSRobotsConfigExtensionTest extends SapphireTest
 {
     protected $usesDatabase = true;
+
+    protected static $required_extensions = [
+        SiteConfig::class => [SSRobotsConfigExtension::class],
+    ];
 
     public function testRobotsTextFieldAddedToSiteConfig(): void
     {

--- a/tests/Extensions/SiteTreeRobotsExtensionTest.php
+++ b/tests/Extensions/SiteTreeRobotsExtensionTest.php
@@ -4,12 +4,17 @@ namespace CatchDesign\SS\SEO\Tests\Extensions;
 
 use CatchDesign\SS\SEO\Extensions\SiteTreeRobotsExtension;
 use Page;
+use SilverStripe\CMS\Model\SiteTree;
 use SilverStripe\Dev\FunctionalTest;
 use SilverStripe\Forms\CheckboxSetField;
 
 class SiteTreeRobotsExtensionTest extends FunctionalTest
 {
     protected $usesDatabase = true;
+
+    protected static $required_extensions = [
+        SiteTree::class => [SiteTreeRobotsExtension::class],
+    ];
 
     public function testXRobotsTagHeaderIsSetOnPageResponse(): void
     {


### PR DESCRIPTION
## Summary

- Removed all 3 auto-applied extension registrations from `_config/config.yml` (SiteConfig, SiteTree x2)
- Kept Injector config and `enable_seo_cache_lifetime` setting
- Projects must now opt in to extensions via their own YAML config
- Updated README.md with Setup section containing YAML snippets for all extensions

## Breaking change

Extensions are no longer automatically applied to SiteConfig and SiteTree. Add the ones you need to your project config — see the Setup section in README.md.

## Test plan

- [x] Tests pass with same results as `release/6` base (pre-existing SapphireTest errors unrelated)
- [x] `_config/config.yml` no longer references framework classes for extensions
- [x] README documents all 3 extensions with YAML snippets

🤖 Generated with [Claude Code](https://claude.com/claude-code)